### PR TITLE
Threshold feature and bugfixes

### DIFF
--- a/TextureAtlas to GIF and Frames.py
+++ b/TextureAtlas to GIF and Frames.py
@@ -193,15 +193,13 @@ def extract_sprites(atlas_path, xml_path, output_dir, create_gif, create_webp, s
                 images[0].save(os.path.join(output_dir, f"_{animation_name}.webp"), save_all=True, append_images=images[1:], disposal=2, duration=durations, loop=0, lossless=True)
 
             if create_gif:
-                quantized = []
                 for frame in images:
-                    channels = frame.split()
-                    alpha = channels[3].point(lambda i: i > 255*threshold and 255)
-                    channels[3].paste(alpha)
-                    quantized.append(Image.merge('RGBA', channels))
+                    alpha = frame.getchannel('A')
+                    alpha = alpha.point(lambda i: i > 255*threshold and 255)
+                    frame.putalpha(alpha)
                 durations = [round(1000/fps)] * len(images)
                 durations[-1] = delay
-                quantized[0].save(os.path.join(output_dir, f"_{animation_name}.gif"), save_all=True, append_images=quantized[1:], disposal=2, optimize=False, duration=durations, loop=0)
+                images[0].save(os.path.join(output_dir, f"_{animation_name}.gif"), save_all=True, append_images=images[1:], disposal=2, optimize=False, duration=durations, loop=0)
 
     except ET.ParseError:
         raise ET.ParseError(f"Badly formatted XML file:\n{xml_path}")

--- a/TextureAtlas to GIF and Frames.py
+++ b/TextureAtlas to GIF and Frames.py
@@ -175,7 +175,6 @@ def extract_sprites(atlas_path, xml_path, output_dir, create_gif, create_webp, s
             sizes = (frame.size for frame in images)
             max_size = tuple(map(max, zip(*sizes)))
             min_size = tuple(map(min, zip(*sizes)))
-            print(max_size)
             if max_size != min_size:
                 for index, frame in enumerate(images):
                     images[index] = Image.new('RGBA', max_size)

--- a/TextureAtlas to GIF and Frames.py
+++ b/TextureAtlas to GIF and Frames.py
@@ -77,6 +77,7 @@ def select_directory(variable, label):
             listbox_xml.bind('<Double-1>', on_double_click_xml)
             
 def on_double_click_xml(evt):
+    spritesheet_name = listbox_png.get(listbox_png.curselection())
     animation_name = listbox_xml.get(listbox_xml.curselection())
     new_window = tk.Toplevel()
     new_window.geometry("360x240")
@@ -89,18 +90,22 @@ def on_double_click_xml(evt):
     delay_entry = tk.Entry(new_window)
     delay_entry.pack()
 
+    tk.Label(new_window, text="Threshold for " + animation_name).pack()
+    threshold_entry = tk.Entry(new_window)
+    threshold_entry.pack()
+
     def store_input():
         try:
-            user_fps_and_delay[animation_name] = (int(fps_entry.get()), int(delay_entry.get()))
+            user_settings[spritesheet_name + '/' + animation_name] = (int(fps_entry.get()), int(delay_entry.get()), float(threshold_entry.get()))
             new_window.destroy()
         except ValueError:
             messagebox.showerror("Invalid input", "Please enter a valid integer for FPS and delay.")
             new_window.lift()
 
     tk.Button(new_window, text="OK", command=store_input).pack()
-user_fps_and_delay = {}
+user_settings = {}
 
-def process_directory(input_dir, output_dir, progress_var, tk_root, create_gif, create_webp, set_framerate, set_loopdelay):
+def process_directory(input_dir, output_dir, progress_var, tk_root, create_gif, create_webp, set_framerate, set_loopdelay, set_threshold):
     progress_var.set(0)
     total_files = count_png_files(input_dir)
     progress_bar["maximum"] = total_files
@@ -116,7 +121,7 @@ def process_directory(input_dir, output_dir, progress_var, tk_root, create_gif, 
                 if os.path.isfile(xml_path):
                     sprite_output_dir = os.path.join(output_dir, filename.rsplit('.', 1)[0])
                     os.makedirs(sprite_output_dir, exist_ok=True)
-                    future = executor.submit(extract_sprites, os.path.join(input_dir, filename), xml_path, sprite_output_dir, create_gif, create_webp, set_framerate, set_loopdelay)
+                    future = executor.submit(extract_sprites, os.path.join(input_dir, filename), xml_path, sprite_output_dir, create_gif, create_webp, set_framerate, set_loopdelay, set_threshold)
                     futures.append(future)
 
         for future in concurrent.futures.as_completed(futures):
@@ -137,12 +142,13 @@ def process_directory(input_dir, output_dir, progress_var, tk_root, create_gif, 
     messagebox.showinfo("Information","Finished processing all files.")
 
 ## Extraction logic
-def extract_sprites(atlas_path, xml_path, output_dir, create_gif, create_webp, set_framerate, set_loopdelay):
+def extract_sprites(atlas_path, xml_path, output_dir, create_gif, create_webp, set_framerate, set_loopdelay, set_threshold):
     try:
         atlas = Image.open(atlas_path)
         tree = ET.parse(xml_path)
         root = tree.getroot()
         animations = {}
+        spritesheet_name = os.path.split(atlas_path)[1]
 
         for sprite in root.findall('SubTexture'):
             name = sprite.get('name')
@@ -172,6 +178,7 @@ def extract_sprites(atlas_path, xml_path, output_dir, create_gif, create_webp, s
                 animations.setdefault(folder_name, []).append(frame_image)
                 
         for animation_name, images in animations.items():
+            fps, delay, threshold = user_settings.get(spritesheet_name + '/' + animation_name, (set_framerate, set_loopdelay, set_threshold))
             sizes = (frame.size for frame in images)
             max_size = tuple(map(max, zip(*sizes)))
             min_size = tuple(map(min, zip(*sizes)))
@@ -181,7 +188,6 @@ def extract_sprites(atlas_path, xml_path, output_dir, create_gif, create_webp, s
                     images[index].paste(frame)
 
             if create_webp:
-                fps, delay = user_fps_and_delay.get(animation_name, (set_framerate, set_loopdelay))
                 durations = [round(1000/fps)] * len(images)
                 durations[-1] = delay
                 images[0].save(os.path.join(output_dir, f"_{animation_name}.webp"), save_all=True, append_images=images[1:], disposal=2, duration=durations, loop=0, lossless=True)
@@ -190,10 +196,9 @@ def extract_sprites(atlas_path, xml_path, output_dir, create_gif, create_webp, s
                 quantized = []
                 for frame in images:
                     channels = frame.split()
-                    alpha = channels[3].point(lambda i: i > 255*0.5 and 255)
+                    alpha = channels[3].point(lambda i: i > 255*threshold and 255)
                     channels[3].paste(alpha)
                     quantized.append(Image.merge('RGBA', channels))
-                fps, delay = user_fps_and_delay.get(animation_name, (set_framerate, set_loopdelay))
                 durations = [round(1000/fps)] * len(images)
                 durations[-1] = delay
                 quantized[0].save(os.path.join(output_dir, f"_{animation_name}.gif"), save_all=True, append_images=quantized[1:], disposal=2, optimize=False, duration=durations, loop=0)
@@ -262,7 +267,13 @@ loopdelay_label.pack()
 loopdelay_entry = tk.Entry(root, textvariable=set_loopdelay)
 loopdelay_entry.pack()
 
-process_button = tk.Button(root, text="Start process", cursor="hand2", command=lambda: process_directory(input_dir.get(), output_dir.get(), progress_var, root, create_gif.get(), create_webp.get(), set_framerate.get(), set_loopdelay.get()))
+set_threshold = tk.DoubleVar(value=0.5)
+threshold_label = tk.Label(root, text="Alpha Threshold:")
+threshold_label.pack()
+threshold_entry = tk.Entry(root, textvariable=set_threshold)
+threshold_entry.pack()
+
+process_button = tk.Button(root, text="Start process", cursor="hand2", command=lambda: process_directory(input_dir.get(), output_dir.get(), progress_var, root, create_gif.get(), create_webp.get(), set_framerate.get(), set_loopdelay.get(), set_threshold.get()))
 process_button.pack(pady=8)
 
 author_label = tk.Label(root, text="Tool written by AutisticLulu")


### PR DESCRIPTION
- Fix crash when an animation has different size frames
- Add threshold option for handling semi-transparent pixels
- Improve handling of some XMLs with unusual SubTexture names, such as those with ".png" suffix or more than 4 digits at the end
- Fix bug where animations of the same name from different spritesheets cannot have their settings set independently