### PR TITLE
Set min_period default to 0

### DIFF
--- a/TextureAtlas to GIF and Frames.py
+++ b/TextureAtlas to GIF and Frames.py
@@ -972,7 +972,7 @@ loopdelay_label.pack()
 loopdelay_entry = tk.Entry(root, textvariable=set_loopdelay)
 loopdelay_entry.pack()
 
-set_minperiod = tk.DoubleVar(value=500)
+set_minperiod = tk.DoubleVar(value=0)
 minperiod_label = tk.Label(root, text="Minimum Period (ms):")
 minperiod_label.pack()
 minperiod_entry = tk.Entry(root, textvariable=set_minperiod)


### PR DESCRIPTION
In 1.8 and earlier with default settings, the final frame would always be 150 ms longer than all the other frames. However, with min_period set to 500 ms in 1.9's defaults, this behavior changed so that the final frame may be extended beyond this point to keep the total animation runtime at least 500 ms. This change reverts to the former behavior.