### PR TITLE
Restore custom frame selection and "None" option

### DIFF
--- a/src/Main.py
+++ b/src/Main.py
@@ -410,6 +410,8 @@ class TextureAtlasExtractorApp:
             "First",
             "Last",
             "First, Last",
+            "None",
+            #"Choose",
         )
         self.frame_selection_menu.pack(pady=(0, 5))
 
@@ -1004,7 +1006,7 @@ class TextureAtlasExtractorApp:
                 widget_info["frame"].pack_forget()
         else:
             self.frame_selection_label.config(state="normal")
-            self.frame_selection_menu.config(state="readonly")
+            self.frame_selection_menu.config(state="normal")
             self.frame_scale_label.config(state="normal")
             self.frame_scale_entry.config(state="normal")
             self._on_frame_compression_change()


### PR DESCRIPTION
Note: Preferences is still limited to the same frame selection options.

There is also a commented-out option that would let the user to choose a single frame to save, which would allow it to be saved without any suffix.